### PR TITLE
Fixed Connection problem URL formats  #198

### DIFF
--- a/src/app/components/SelectNode/InputAddress.tsx
+++ b/src/app/components/SelectNode/InputAddress.tsx
@@ -28,12 +28,6 @@ export default class InputAddress extends React.Component<Props, State> {
     const { error, isCheckingNode } = this.props;
     const { validation, url, submittedUrl } = this.state;
     const validateStatus = url ? validation ? 'error' : 'success' : undefined;
-    // Handle accidental user input after port number
-    const modUrl = submittedUrl.split(":");
-    // Basically just break apart the URL
-    const modPort = modUrl[2].split("/");
-    // Eliminate anything after port number and bring back together
-    const altUrl = `${modUrl[0]}:${modUrl[1]}:${modPort[0]}`;
     const help = (url && validation) || (
       <>
         You must provide the REST API address. Must begin with{' '}
@@ -62,7 +56,7 @@ export default class InputAddress extends React.Component<Props, State> {
               <p>Request failed with the message "{error.message}"</p>
               <p>
                 If you're sure you've setup your node correctly, try{' '}
-                <a href={`${altUrl}/v1/getinfo`} target="_blank">
+                <a href={`${submittedUrl}/v1/getinfo`} target="_blank">
                   clicking this link
                 </a>{' '}
                 and making sure it loads correctly. If there are SSL errors,
@@ -101,6 +95,7 @@ export default class InputAddress extends React.Component<Props, State> {
   };
 
   private handleSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
+    const url = this.state.url.replace(/\/$/, '')
     ev.preventDefault();
     browser.permissions.request({
       origins: [urlWithoutPort(this.state.url)],
@@ -108,8 +103,8 @@ export default class InputAddress extends React.Component<Props, State> {
       if (!accepted) {
         message.warn('Permission denied, connection may fail');
       }
-      this.props.submitUrl(this.state.url);
-      this.setState({ submittedUrl: this.state.url });
+      this.props.submitUrl(url);
+      this.setState({ submittedUrl: url });
     });
   };
 }

--- a/src/app/components/SelectNode/InputAddress.tsx
+++ b/src/app/components/SelectNode/InputAddress.tsx
@@ -28,6 +28,12 @@ export default class InputAddress extends React.Component<Props, State> {
     const { error, isCheckingNode } = this.props;
     const { validation, url, submittedUrl } = this.state;
     const validateStatus = url ? validation ? 'error' : 'success' : undefined;
+    // Handle accidental user input after port number
+    const modUrl = submittedUrl.split(":");
+    // Basically just break apart the URL
+    const modPort = modUrl[2].split("/");
+    // Eliminate anything after port number and bring back together
+    const altUrl = `${modUrl[0]}:${modUrl[1]}:${modPort[0]}`;
     const help = (url && validation) || (
       <>
         You must provide the REST API address. Must begin with{' '}
@@ -56,7 +62,7 @@ export default class InputAddress extends React.Component<Props, State> {
               <p>Request failed with the message "{error.message}"</p>
               <p>
                 If you're sure you've setup your node correctly, try{' '}
-                <a href={`${submittedUrl}/v1/getinfo`} target="_blank">
+                <a href={`${altUrl}/v1/getinfo`} target="_blank">
                   clicking this link
                 </a>{' '}
                 and making sure it loads correctly. If there are SSL errors,

--- a/src/app/components/SelectNode/InputAddress.tsx
+++ b/src/app/components/SelectNode/InputAddress.tsx
@@ -98,7 +98,7 @@ export default class InputAddress extends React.Component<Props, State> {
     const url = this.state.url.replace(/\/$/, '')
     ev.preventDefault();
     browser.permissions.request({
-      origins: [urlWithoutPort(this.state.url)],
+      origins: [urlWithoutPort(url)],
     }).then(accepted => {
       if (!accepted) {
         message.warn('Permission denied, connection may fail');


### PR DESCRIPTION
Closes #198 

### URL double-slash when adding slash during initial setup

Modified InputAddress.tsx 'submittedUrl' value in the state. The submitted URL is decomposed and only the host and port are extracted. Any additional characters after the port number are removed and joined with remaining test URL /v1/getinfo.

### Steps to Test

1. Clear browser history
2. Begin to setup the Joule Extension
3. Enter URL with trailing foward slash on the Failed to connect screen
4. Verify no additional slashes are added
