### PR TITLE
Fix pathless transactions crashing tx list

### DIFF
--- a/src/app/components/Identicon.tsx
+++ b/src/app/components/Identicon.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import { toSvg } from 'jdenticon';
+import { Icon } from 'antd';
 import './Identicon.less';
 
 interface Props extends React.HTMLProps<HTMLDivElement> {
@@ -10,14 +11,23 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
 
 const Identicon: React.SFC<Props> = ({ pubkey, size, ...rest }) => {
   size = size || 100;
-  const identicon = toSvg(pubkey, size || 100);
-  return (
-    <div
-      {...rest}
-      className={classnames('Identicon', rest.className)}
-      dangerouslySetInnerHTML={{ __html: identicon }}
-    />
-  );
+  let identicon;
+  if (pubkey) {
+    identicon = toSvg(pubkey, size || 100);
+    return (
+      <div
+        {...rest}
+        className={classnames('Identicon', rest.className)}
+        dangerouslySetInnerHTML={{ __html: identicon }}
+      />
+    );
+  } else {
+    return (
+      <div className={classnames('Identicon', rest.className)}>
+        <Icon type="question" />
+      </div>
+    );
+  }
 };
 
 export default Identicon;

--- a/src/app/components/TransactionInfo/index.tsx
+++ b/src/app/components/TransactionInfo/index.tsx
@@ -7,6 +7,7 @@ import Unit from 'components/Unit';
 import Copy from 'components/Copy';
 import DetailsTable, { DetailsRow } from 'components/DetailsTable';
 import TransferIcons, { TransferParty } from 'components/TransferIcons';
+import BigMessage from 'components/BigMessage';
 import { ellipsisSandwich } from 'utils/formatters';
 import { getAccountInfo } from 'modules/account/actions';
 import { AnyTransaction } from 'modules/account/types';
@@ -75,13 +76,20 @@ class TransactionInfo extends React.Component<Props> {
         <div className="TxInfo-route">
           <h2 className="TxInfo-route-title">Route</h2>
           <div className="TxInfo-route-routes">
-            <Timeline>
-              {tx.path.map(id => (
-                <Timeline.Item key={id}>
-                  <code>{id}</code>
-                </Timeline.Item>
-              ))}
-            </Timeline>
+            {tx.path.length ? (
+              <Timeline>
+                {tx.path.map(id => (
+                  <Timeline.Item key={id}>
+                    <code>{id}</code>
+                  </Timeline.Item>
+                ))}
+              </Timeline>
+            ) : (
+              <BigMessage
+                title="No route info available"
+                message="This payment may be too old, and not have stored routing data"
+              />
+            )}
           </div>
         </div>
       );

--- a/src/app/components/TransactionInfo/style.less
+++ b/src/app/components/TransactionInfo/style.less
@@ -2,6 +2,8 @@
 @icon-size: 4.6rem;
 
 .TxInfo {
+  padding-bottom: 1rem;
+
   > *:last-child {
     margin-bottom: 0;
   }
@@ -56,6 +58,10 @@
       code {
         font-size: 0.8rem;
       }
+    }
+
+    .BigMessage {
+      padding: 1rem;
     }
   }
 }

--- a/src/app/components/TransactionList/TransactionRow.tsx
+++ b/src/app/components/TransactionList/TransactionRow.tsx
@@ -35,7 +35,7 @@ class TransactionRow extends React.Component<Props> {
     const { pubkey, timestamp, status, delta, onClick, source, title, chain } = this.props;
 
     let icon;
-    if (pubkey) {
+    if (pubkey !== null && pubkey !== undefined) {
       icon = <Identicon className="TransactionRow-avatar-img" pubkey={pubkey} />;
     } else if (isInvoice(source)) {
       icon = (

--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -189,6 +189,7 @@ export class LndHttpClient {
     ).then(res => {
       res.payments = res.payments.map(t => ({
         fee: '0',
+        path: [],
         ...t,
       }));
       return res;

--- a/src/app/utils/misc.ts
+++ b/src/app/utils/misc.ts
@@ -2,6 +2,7 @@ import {
   LndHttpClient,
   GetNodeInfoResponse,
   AlreadyConnectedError,
+  LightningNode,
 } from 'lib/lnd-http';
 
 export function sleep(time: number) {
@@ -10,11 +11,35 @@ export function sleep(time: number) {
   });
 }
 
+export const OFFLINE_NODE: LightningNode = {
+  alias: '<Offline node>',
+  color: '000000',
+  addresses: [],
+  last_update: 0,
+  pub_key: '',
+};
+
+export const UNKNOWN_NODE: LightningNode = {
+  alias: '<Unknown node>',
+  color: '000000',
+  addresses: [],
+  last_update: 0,
+  pub_key: '',
+};
+
 // Run getNodeInfo, but if it fails, return a spoofed node object
 export async function safeGetNodeInfo(
   lib: LndHttpClient,
   pubkey: string,
 ): Promise<GetNodeInfoResponse> {
+  if (!pubkey) {
+    return {
+      total_capacity: 0,
+      num_channels: 0,
+      node: UNKNOWN_NODE,
+    };
+  }
+
   try {
     const node = await lib.getNodeInfo(pubkey);
     return node;
@@ -23,10 +48,7 @@ export async function safeGetNodeInfo(
       total_capacity: 0,
       num_channels: 0,
       node: {
-        alias: '<Offline node>',
-        color: '000000',
-        addresses: [],
-        last_update: 0,
+        ...OFFLINE_NODE,
         pub_key: pubkey,
       },
     };


### PR DESCRIPTION
Closes #206

### Description

Fixes some payments (I think only quite old ones) from crashing the transactions tab. This happened due to them coming back with `undefined` paths. In total, this PR does the following:

* Defaults the `path` array to `[]` if undefined
* Improves the display of pathless payments
* Improves the Identicon component by having it display a (?) when the pubkey is falsy

### Steps to Test

1. Get a pathless payment, or alter the code so that you can forcefully induce one
2. Load the transactions tab, confirm it doesn't crash
3. Open a pathless transaction, confirm it displays correctly

## Screenshots

### List view

<img width="401" alt="Screen Shot 2019-04-24 at 2 26 18 PM" src="https://user-images.githubusercontent.com/649992/56684490-de7ad000-669d-11e9-847a-246e80a0985c.png">

### Detail view

<img width="348" alt="Screen Shot 2019-04-24 at 2 28 40 PM" src="https://user-images.githubusercontent.com/649992/56684492-e0449380-669d-11e9-85dd-eade69271bdb.png">
