### PR TITLE
Sync warning

### DIFF
--- a/src/app/components/AccountInfo/index.tsx
+++ b/src/app/components/AccountInfo/index.tsx
@@ -9,18 +9,21 @@ import Unit from 'components/Unit';
 import DepositModal from './DepositModal';
 import NodeUriModal from './NodeUriModal';
 import { getAccountInfo } from 'modules/account/actions';
-import { getNodeChain } from 'modules/node/selectors';
+import { getNodeInfo } from 'modules/node/actions';
+import { getNodeChain, selectNodeInfo } from 'modules/node/selectors';
 import { blockchainDisplayName } from 'utils/constants';
 import { AppState } from 'store/reducers';
 import './style.less';
 
 interface StateProps {
   account: AppState['account']['account'];
+  nodeInfo: ReturnType<typeof selectNodeInfo>;
   chain: ReturnType<typeof getNodeChain>;
 }
 
 interface DispatchProps {
   getAccountInfo: typeof getAccountInfo;
+  getNodeInfo: typeof getNodeInfo
 }
 
 interface OwnProps {
@@ -45,10 +48,13 @@ class AccountInfo extends React.Component<Props, State> {
     if (!this.props.account) {
       this.props.getAccountInfo();
     }
+    if (!this.props.nodeInfo) {
+      this.props.getNodeInfo();
+    }
   }
 
   render() {
-    const { account, chain } = this.props;
+    const { account, nodeInfo, chain } = this.props;
     const { isDepositModalOpen,isNodeUriModalOpen } = this.state;
     const actions: ButtonProps[] = [{
       children: 'Deposit',
@@ -116,6 +122,12 @@ class AccountInfo extends React.Component<Props, State> {
           ))}
         </div>
 
+        {nodeInfo && !nodeInfo.synced_to_chain && (
+          <div className="AccountInfo-syncWarning">
+            <Icon type="warning" /> Node is syncing to chain, balances may be incorrect
+          </div>
+        )}
+
         {account &&
           <DepositModal
             isOpen={isDepositModalOpen}
@@ -143,9 +155,11 @@ class AccountInfo extends React.Component<Props, State> {
 export default connect<StateProps, DispatchProps, {}, AppState>(
   state => ({
     account: state.account.account,
+    nodeInfo: selectNodeInfo(state),
     chain: getNodeChain(state),
   }),
   {
+    getNodeInfo,
     getAccountInfo,
   },
 )(AccountInfo);

--- a/src/app/components/AccountInfo/style.less
+++ b/src/app/components/AccountInfo/style.less
@@ -72,4 +72,16 @@
       }
     }
   }
+
+  &-syncWarning {
+    margin-left: -1.25rem;
+    margin-right: -1.25rem;
+    margin-bottom: -0.75rem;
+    margin-top: 1rem;
+    padding: 0.3rem;
+    background: @warning-color;
+    color: #FFF;
+    text-align: center;
+    font-size: 0.8rem;
+  }
 }


### PR DESCRIPTION
Closes #199

### Description

Adds a banner when your node is still syncing to the chain to let you know that your balances might be off. To my knowledge there's no way to get progress, since it always reports the bitcoin node's block height, not LND's current scan progress, so the best we can do is this boolean display.

### Steps to Test

Open joule with a syncing node (or induce the state yourself programmatically), confirm you see a banner.

## Screenshots

<img width="414" alt="Screen Shot 2019-04-24 at 5 02 08 PM" src="https://user-images.githubusercontent.com/649992/56693708-2e17c680-66b3-11e9-8eee-01cac7fe7fc1.png">
