### PR TITLE
Provide private channel route hints & make private routes sendable

### DIFF
--- a/src/app/components/ChannelList/ChannelRow.less
+++ b/src/app/components/ChannelList/ChannelRow.less
@@ -30,14 +30,18 @@
       }
     }
 
-    &-status {
+    &-status,
+    &-private {
       position: absolute;
       bottom: 0.1rem;
-      right: 0.1rem;
-      width: 0.8rem;
-      height: 0.8rem;
+      width: 0.9rem;
+      height: 0.9rem;
       border-radius: 100%;
-      box-shadow: 0 0 0 3px #FFF;
+      box-shadow: 0 0 0 3px #fff;
+    }
+
+    &-status {
+      right: 0.1rem;
 
       &.is-open {
         &.is-active {
@@ -51,8 +55,21 @@
       &.is-closing,
       &.is-opening,
       &.is-waiting,
-      &.is-force-closing, {
+      &.is-force-closing {
         background: @warning-color;
+      }
+    }
+
+    &-private {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      left: 0.1rem;
+      background: #666;
+
+      .anticon {
+        color: #fff;
+        font-size: 0.65rem;
       }
     }
   }
@@ -66,7 +83,7 @@
       font-size: 0.95rem;
       margin-bottom: 0.1rem;
     }
-    
+
     &-pubkey {
       font-size: 0.65rem;
       margin-bottom: 0.15rem;

--- a/src/app/components/ChannelList/ChannelRow.tsx
+++ b/src/app/components/ChannelList/ChannelRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import BN from 'bn.js';
-import { Tooltip } from 'antd';
+import { Tooltip, Icon } from 'antd';
 import classnames from 'classnames';
 import Identicon from 'components/Identicon';
 import Unit from 'components/Unit';
@@ -36,6 +36,8 @@ export default class ChannelRow extends React.Component<Props> {
       statusClass = `${statusClass} is-${channel.active ? 'active' : 'inactive'}`;
     }
 
+    const isPrivate = channel.status === CHANNEL_STATUS.OPEN ? channel.private : false;
+
     return (
       <div
         className={classnames('ChannelRow', onClick && 'is-clickable')}
@@ -46,6 +48,14 @@ export default class ChannelRow extends React.Component<Props> {
           <Tooltip title={tooltipText}>
             <div className={classnames('ChannelRow-avatar-status', statusClass)} />
           </Tooltip>
+
+          {isPrivate && (
+            <Tooltip title="Private">
+              <div className="ChannelRow-avatar-private">
+                <Icon type="eye-invisible" theme="filled" />
+              </div>
+            </Tooltip>
+          )}
         </div>
         <div className="ChannelRow-info">
           <div className="ChannelRow-info-alias">{node.alias}</div>

--- a/src/app/components/Help/index.less
+++ b/src/app/components/Help/index.less
@@ -1,5 +1,5 @@
 .Help {
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
   width: 0.8rem;

--- a/src/app/components/Help/index.less
+++ b/src/app/components/Help/index.less
@@ -1,0 +1,11 @@
+.Help {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 0.8rem;
+  height: 0.8rem;
+
+  .anticon {
+    color: rgba(#000, 0.4);
+  }
+}

--- a/src/app/components/Help/index.tsx
+++ b/src/app/components/Help/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Popover, Icon } from 'antd';
+import './index.less';
+
+interface Props {
+  title?: string;
+  children: React.ReactNode;
+}
+
+const Help: React.SFC<Props> = ({ children, title }) => (
+  <Popover content={children} title={title} arrowPointAtCenter>
+    <div className="Help">
+      <Icon type="question-circle" theme="filled" />
+    </div>
+  </Popover>
+);
+
+export default Help;

--- a/src/app/components/InvoiceForm/style.less
+++ b/src/app/components/InvoiceForm/style.less
@@ -6,11 +6,16 @@
   }
 
   &-form {
-    &-anyValue {
-      margin-top: -0.25rem;
-      margin-bottom: 0.5rem;
-      transform: scale(0.8);
+    &-anyValue,
+    &-private {
+      margin-bottom: 0.25rem;
+      transform: translateY(-30%) scale(0.8);
       transform-origin: left center;
+    }
+
+    &-private {
+      display: flex;
+      align-items: center;
     }
   }
 
@@ -27,9 +32,8 @@
       padding: 1rem;
       margin-bottom: 0.5rem;
       border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2),
-                  0 0 2px rgba(0, 0, 0, 0.2);
-      
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 0 2px rgba(0, 0, 0, 0.2);
+
       canvas {
         display: block;
       }

--- a/src/app/components/SendForm/LightningSend.tsx
+++ b/src/app/components/SendForm/LightningSend.tsx
@@ -16,9 +16,9 @@ import {
   resetSendPayment,
 } from 'modules/payment/actions';
 import { PaymentRequestData } from 'modules/payment/types';
+import { getNodeChain } from 'modules/node/selectors';
 import { AppState } from 'store/reducers';
 import './LightningSend.less';
-import { getNodeChain } from 'modules/node/selectors';
 
 interface StateProps {
   paymentRequests: AppState['payment']['paymentRequests'];

--- a/src/app/components/Unit.tsx
+++ b/src/app/components/Unit.tsx
@@ -40,6 +40,11 @@ class Unit extends React.Component<Props> {
       chain,
     } = this.props;
 
+    // If we get a non-number, just early return with it plaintext
+    if (Number.isNaN(parseInt(value, 10))) {
+      return <span className="Unit">{value}</span>;
+    }
+
     // Store & remove negative
     const prefix = value[0] === '-' ? '-' : showPlus ? '+' : '';
     value = value.replace('-', '');

--- a/src/app/lib/lnd-http/types.ts
+++ b/src/app/lib/lnd-http/types.ts
@@ -333,6 +333,7 @@ export interface CreateInvoiceArguments {
   memo?: string;
   expiry?: string | number;
   fallback_addr?: string;
+  private?: boolean;
 }
 
 export interface CreateInvoiceResponse {

--- a/src/app/modules/payment/sagas.ts
+++ b/src/app/modules/payment/sagas.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from 'redux-saga';
-import { takeEvery, call, all, select, put } from 'redux-saga/effects';
+import { takeEvery, call, select, put } from 'redux-saga/effects';
 import {
   selectNodeLibOrThrow,
   selectNodeInfo,
@@ -79,14 +79,18 @@ export function* handleCheckPaymentRequest(
   action: ReturnType<typeof checkPaymentRequest>,
 ): SagaIterator {
   const { paymentRequest, amount } = action.payload;
-  let decodedRequest: Yielded<typeof nodeLib.decodePaymentRequest>;
-  let nodeInfo: Yielded<typeof nodeLib.getNodeInfo>;
+  let nodeLib: Yielded<typeof selectNodeLibOrThrow>;
+  let decodedRequest: Yielded<typeof nodeLib.decodePaymentRequest> | undefined;
+  let nodeInfo: Yielded<typeof nodeLib.getNodeInfo> | undefined;
   try {
-    const nodeLib: Yielded<typeof selectNodeLibOrThrow> = yield select(
-      selectNodeLibOrThrow,
-    );
-    decodedRequest = yield call(nodeLib.decodePaymentRequest, paymentRequest);
-    nodeInfo = yield call(nodeLib.getNodeInfo, decodedRequest.destination);
+    nodeLib = yield select(selectNodeLibOrThrow);
+    decodedRequest = (yield call(
+      nodeLib.decodePaymentRequest,
+      paymentRequest,
+    )) as Yielded<typeof nodeLib.decodePaymentRequest>;
+    nodeInfo = (yield call(nodeLib.getNodeInfo, decodedRequest.destination)) as Yielded<
+      typeof nodeLib.getNodeInfo
+    >;
     const routeInfo: Yielded<typeof nodeLib.queryRoutes> = yield call(
       nodeLib.queryRoutes,
       decodedRequest.destination,

--- a/src/app/prompts/invoice.less
+++ b/src/app/prompts/invoice.less
@@ -7,7 +7,7 @@
     text-transform: uppercase;
     font-weight: bold;
     letter-spacing: 0.1rem;
-    opacity: 0.7;
+    color: @text-color-secondary;
   }
 
   &-header {
@@ -15,8 +15,8 @@
     align-items: center;
     padding: 1rem;
     margin-bottom: 1rem;
-    background: #FFF;
-    border-bottom: 1px solid #EEE;
+    background: #fff;
+    border-bottom: 1px solid #eee;
 
     &-icon {
       img {
@@ -73,7 +73,11 @@
     }
 
     &-advanced {
-      display: flex;
+      &-private {
+        display: flex;
+        align-items: center;
+        transform: translateY(-1rem);
+      }
 
       .ant-form-item {
         flex: 1;
@@ -88,8 +92,14 @@
         padding-bottom: 0;
 
         label {
+          display: flex;
+          align-items: center;
           font-size: 0.7rem;
           letter-spacing: 0.08rem;
+
+          .Help {
+            margin-left: 0.25rem;
+          }
         }
       }
 

--- a/src/app/style.less
+++ b/src/app/style.less
@@ -11,7 +11,7 @@ body {
   padding: 0;
   font-family: @font-family;
   color: #4d4d4d;
-  background: #FBFBFB;
+  background: #fbfbfb;
 
   @media (min-width: 500px) {
     background-image: url('~static/images/bg.png');
@@ -56,6 +56,7 @@ body {
 }
 
 // ensure modals display above drawers
-.ant-modal-mask, .ant-modal-wrap {
+.ant-modal-mask,
+.ant-modal-wrap {
   z-index: 1001;
 }


### PR DESCRIPTION
Closes #192 

### Description

This makes invoice creations include private route hints, and also works around the issue where you were unable to send invoices that relied on private routes due to QueryRoute's inability to take in routing hints, and Joule's running of QueryRoutes before letting a user send to ensure that there _is_ a route and to provide the user fee information before they send.

The latter part of this should be moot as soon as this PR is merged https://github.com/lightningnetwork/lnd/pull/2186 but even then will stay an issue for folks running older node versions for a while. This janky temporary fix of returning placeholder routing info will probably have to sit in for a while until there's a reasonable expectation that most people have upgraded.

I also make a `Help` component and used it in a couple spots to explain some stuff.

### Steps to Test

1. Have a private channel open on your node
2. Generate an invoice with the routing hints checkbox checked
3. Run your invoice through https://lndecode.com/ and confirm the `routing_information` info is provided and correct
4. Generate an invoice with the routing hints checkbox unchecked
5. Run it through lndecode again, confirm the `routing_information` info is not provided
6. Attempt to pay the invoice you generated in step 2, confirm that you are able to attempt a send in spite of the fact that QueryRoutes failed
7. Attempt to pay the invoice you generated in step 4, confirm that you are unable to attempt a send since it has no routing information

### Screenshots

### Invoice form w/ checkbox

<img width="357" alt="Screen Shot 2019-06-04 at 1 45 48 PM" src="https://user-images.githubusercontent.com/649992/58902707-a5d50a00-86d1-11e9-8037-ca4adaac3c52.png">

### Help Tooltip

<img width="402" alt="Screen Shot 2019-06-04 at 1 45 55 PM" src="https://user-images.githubusercontent.com/649992/58902678-91910d00-86d1-11e9-9e65-d0e9ffaceb26.png">

### Invoice prompt with advanced expanded

<img width="387" alt="Screen Shot 2019-06-04 at 1 46 13 PM" src="https://user-images.githubusercontent.com/649992/58902672-8dfd8600-86d1-11e9-8222-8286da3e7e97.png">

### Display of fees with private routing

<img width="512" alt="Screen Shot 2019-06-04 at 1 47 05 PM" src="https://user-images.githubusercontent.com/649992/58902763-bf765180-86d1-11e9-87cd-74eb682c3ca7.png">
