### PR TITLE
fixes bits/mBTC inversion

### DIFF
--- a/src/app/utils/units.ts
+++ b/src/app/utils/units.ts
@@ -10,8 +10,8 @@ import { commaify } from './formatters';
 
 const decimals: { [key in Denomination]: number } = {
   [Denomination.SATOSHIS]: 0,
-  [Denomination.MILLIBITCOIN]: 3,
-  [Denomination.BITS]: 6,
+  [Denomination.BITS]: 3,
+  [Denomination.MILLIBITCOIN]: 6,
   [Denomination.BITCOIN]: 8,
 };
 


### PR DESCRIPTION
Closes #223 

### Description

The change is very simple and local: the structure containing the number of decimal points in the representation of a bitcoin amount at that denomination had two numbers swapped.  I unswapped them.