### PR TITLE
Better errors for WebLN prompts

### DIFF
--- a/src/app/components/PromptTemplate/index.tsx
+++ b/src/app/components/PromptTemplate/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Button, message, Alert } from 'antd';
+import { Button, Alert } from 'antd';
 import { confirmPrompt, rejectPrompt } from 'utils/prompt';
 import './style.less';
 

--- a/src/app/components/PromptTemplate/index.tsx
+++ b/src/app/components/PromptTemplate/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Button, message } from 'antd';
+import { Button, message, Alert } from 'antd';
 import { confirmPrompt, rejectPrompt } from 'utils/prompt';
 import './style.less';
 
@@ -17,21 +17,33 @@ interface Props {
 interface State {
   isConfirming: boolean;
   isRejecting: boolean;
+  error: Error | null;
 }
 
 export default class PromptTemplate extends React.Component<Props, State> {
   state: State = {
     isConfirming: false,
     isRejecting: false,
+    error: null,
   };
 
   render() {
     const { children, isConfirmDisabled, isContentCentered, hasNoButtons } = this.props;
-    const { isConfirming, isRejecting } = this.state;
+    const { isConfirming, isRejecting, error } = this.state;
     const confirmDisabled = isConfirmDisabled || isRejecting;
 
     return (
       <div className="PromptTemplate">
+        {error && (
+          <Alert
+            className="PromptTemplate-error"
+            type="error"
+            message={error.message}
+            onClose={this.closeError}
+            closable
+            banner
+          />
+        )}
         <div
           className={classnames(
             'PromptTemplate-content',
@@ -88,12 +100,18 @@ export default class PromptTemplate extends React.Component<Props, State> {
     if (this.props.getConfirmData) {
       try {
         data = await this.props.getConfirmData();
-      } catch (err) {
-        this.setState({ isConfirming: false });
-        message.error(err.message, 3);
+      } catch (error) {
+        this.setState({
+          isConfirming: false,
+          error,
+        });
         return;
       }
     }
     confirmPrompt(data);
+  };
+
+  private closeError = () => {
+    this.setState({ error: null });
   };
 }

--- a/src/app/components/PromptTemplate/style.less
+++ b/src/app/components/PromptTemplate/style.less
@@ -1,3 +1,5 @@
+@import '~style/variables.less';
+
 .PromptTemplate {
   display: flex;
   flex-direction: column;
@@ -8,7 +10,7 @@
     display: flex;
     flex-direction: column;
     overflow: auto;
-    background: #FAFAFA;
+    background: #fafafa;
 
     &.is-centered {
       justify-content: center;
@@ -17,7 +19,7 @@
 
   &-buttons {
     display: flex;
-    border-top: 1px solid #EEE;
+    border-top: 1px solid #eee;
     justify-content: center;
     align-items: center;
     padding: 0.75rem;


### PR DESCRIPTION
Closes #227

### Description

Changes prompt errors from `message.error` which would disappear automatically, to rendering an `<Alert />` that the user has to manually dismiss. Doesn't look quite as nice, but should be a lot better for longer errors or when the user backgrounds the window and comes back later.

### Steps to Test

1. Go to https://webln.dev/#/api/make-invoice
2. Make an invoice of a number way too high
3. Confirm you get an error
4. Confirm the error doesn't disappear automatically
5. Confirm clicking on the X dismisses the error

### Screenshots

<img width="512" alt="Screen Shot 2019-09-15 at 12 10 23 PM" src="https://user-images.githubusercontent.com/649992/64925135-d12bc280-d7b1-11e9-9b08-042c4715e1f8.png">
