### PR TITLE
Store last payment attempt in the allowance config

### DIFF
--- a/src/app/modules/appconf/types.ts
+++ b/src/app/modules/appconf/types.ts
@@ -12,6 +12,7 @@ export interface Allowance {
   balance: number;
   maxPerPayment: number;
   minIntervalPerPayment: number;
+  lastPaymentAttempt: number;
 }
 
 export interface AppConfig {

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -256,6 +256,7 @@ export const DEFAULT_ALLOWANCE: Allowance = {
   balance: 10000,
   maxPerPayment: 100,
   minIntervalPerPayment: 1,
+  lastPaymentAttempt: 0,
 };
 
 export const COLORS = {

--- a/src/content_script/respondWithoutPrompt.ts
+++ b/src/content_script/respondWithoutPrompt.ts
@@ -12,8 +12,6 @@ import {
 } from '../util/messages';
 import { createNotification, updateNotification } from './notifications';
 
-let lastPaymentAttempt = 0;
-
 export default async function respondWithoutPrompt(
   msg: AnyPromptMessage,
 ): Promise<boolean> {
@@ -63,10 +61,8 @@ async function handleAutoPayment(msg: PaymentPromptMessage) {
   }
 
   // Don't allow payments to happen too fast
-  const last = allowance.lastPaymentAttempt || lastPaymentAttempt;
   const now = Date.now();
-  lastPaymentAttempt = now;
-  if (last + allowance.minIntervalPerPayment * 1000 > now) {
+  if (allowance.lastPaymentAttempt + allowance.minIntervalPerPayment * 1000 > now) {
     console.warn('Site attempted to make payments too fast for allowance payment');
     return false;
   }
@@ -127,7 +123,7 @@ async function handleAutoPayment(msg: PaymentPromptMessage) {
       allowance: {
         ...allowance,
         balance,
-        lastPaymentAttempt,
+        lastPaymentAttempt: now,
       },
     }),
   );

--- a/src/content_script/respondWithoutPrompt.ts
+++ b/src/content_script/respondWithoutPrompt.ts
@@ -63,7 +63,7 @@ async function handleAutoPayment(msg: PaymentPromptMessage) {
   }
 
   // Don't allow payments to happen too fast
-  const last = lastPaymentAttempt;
+  const last = allowance.lastPaymentAttempt || lastPaymentAttempt;
   const now = Date.now();
   lastPaymentAttempt = now;
   if (last + allowance.minIntervalPerPayment * 1000 > now) {
@@ -127,6 +127,7 @@ async function handleAutoPayment(msg: PaymentPromptMessage) {
       allowance: {
         ...allowance,
         balance,
+        lastPaymentAttempt,
       },
     }),
   );


### PR DESCRIPTION
### Description

So far the `lastPaymentAttempt` is not presisted yet and thus the cooldown period for an allowance could not be calculated. 
This change stores the `lastPaymentAttempt` timestamp as part of the allowance config. The default value is 0 as before.