### PR TITLE
Add GitHub workflow to run build:prod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - develop
+    tags:
+      - v*
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build Production
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: build-prod
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+      - run: yarn lint
+      - name: Build production
+        run: yarn build:prod
+
+      - name: Archive production zip file
+        uses: actions/upload-artifact@v2
+        with:
+          name: joule.zip
+          path: dist-prod/joule-*.zip
+
+      - name: Archive production files
+        uses: actions/upload-artifact@v2
+        with:
+          name: joule
+          path: dist-prod/


### PR DESCRIPTION
This GitHub workflow runs a production build on every push to the develop branch (e.g. whenever a pull request is merged) and whenever a version tag is created.
The build artifacts are stored and made available for download. 

You can see the workflow in action here: https://github.com/bumi/joule-extension/actions/runs/346573887
