### PR TITLE
Convert readme to use unix line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@ the ability to pay and use your node as an identity on the web.
 
 **WARNING: Joule is in early alpha, and should not be used for large mainnet funds**
 
-
 <p align="center">
   <a target="_blank" rel="noopener noreferrer" href="https://chrome.google.com/webstore/detail/joule/aejmoogjdllanidlpfjmmmmimfaficio"><img src="https://camo.githubusercontent.com/03f42faaa039db4a737c86efffa8fb51160b1c3e/68747470733a2f2f692e696d6775722e636f6d2f6b5742515539512e706e67" alt="Install for Chrome" data-canonical-src="https://i.imgur.com/kWBQU9Q.png" width="215" style="max-width:100%;"></a>
   <a target="_blank" rel="noopener noreferrer" href="https://chrome.google.com/webstore/detail/joule/aejmoogjdllanidlpfjmmmmimfaficio"><img src="https://camo.githubusercontent.com/28cdbccd978c68df21b742fb5d0122a49977d3ba/68747470733a2f2f692e696d6775722e636f6d2f6c6f71443433312e706e67" alt="Install for Brave" data-canonical-src="https://i.imgur.com/loqD431.png" width="215" style="max-width:100%;"></a>
   <a target="_blank" rel="noopener noreferrer" href="https://addons.mozilla.org/en-US/firefox/addon/lightning-joule/"><img src="https://camo.githubusercontent.com/0ab15bdbdfebab96bdb03d184f60eb0e28169a21/68747470733a2f2f692e696d6775722e636f6d2f614e4342324c472e706e67" alt="Install for Firefox" data-canonical-src="https://i.imgur.com/aNCB2LG.png" width="215" style="max-width:100%;"></a>
   <img src="https://camo.githubusercontent.com/53d25f16497948c065a7570b0075b0eebd795aca/68747470733a2f2f692e696d6775722e636f6d2f7a346c4e6843362e706e67" alt="Opera coming soon" data-canonical-src="https://i.imgur.com/z4lNhC6.png" width="215" style="max-width:100%;">
 </p>
-
 
 ## Project Layout
 
@@ -66,18 +64,21 @@ to the joule folder and run `yarn link webln`.
 NOTE: After making changes, you'll need to close and re-open the extension to load the latest build.
 
 Redux DevTools:
+
 1. Open the extension popup or full page
 2. Right click on the background
 3. Choose Redux Devtools -> Open Remote DevTools
 4. A new window will open displaying the Redux actions list
 
 React DevTools:
+
 1. Run `npm install -g react-devtools`
 2. Be sure to use `yarn run dev` to build the app
-2. Run `react-devtools` in a new Terminal
-3. A new window will open displaying the React vdom inspector
+3. Run `react-devtools` in a new Terminal
+4. A new window will open displaying the React vdom inspector
 
 React Hot Reload:
+
 1. Run `yarn run hot` instead of `yarn run dev`
 
 ## Building
@@ -105,12 +106,12 @@ Please see the [Contributor Guidelines on the Wiki](https://github.com/wbobeirne
 
 ## Shoutouts
 
-* Thanks to the [MetaMask](http://github.com/Metamask) team for establishing
-a ton of the UX best practices for browser crypto payments.
-* Thanks to [@afilini](https://github.com/afilini) for providing a small prototype
-reference implementation of the extension flow.
-* Thanks to [Chaincode Labs](https://chaincode.com) for putting together the 2018
-Lightning residency, where this was born.
+- Thanks to the [MetaMask](http://github.com/Metamask) team for establishing
+  a ton of the UX best practices for browser crypto payments.
+- Thanks to [@afilini](https://github.com/afilini) for providing a small prototype
+  reference implementation of the extension flow.
+- Thanks to [Chaincode Labs](https://chaincode.com) for putting together the 2018
+  Lightning residency, where this was born.
 
 ## Pay me money pls
 


### PR DESCRIPTION
Seems the readme is using DOS line encodings. I think it is common practice to use unix line breaks (which are also supported by windows editors, afaik?)

This PR did a `dos2unix README.md`