### PR TITLE
Add Dockerfile to create production builds of Joule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,16 @@
 # $ docker run --rm -v "$(pwd):/out" joule sh -c "cp /app/dist-prod/joule*.zip /out"
 # ls ./out
 #
-FROM node:lts-alpine
+FROM node:lts
+run apt-get update
+RUN apt-get install strip-nondeterminism --yes
+
 WORKDIR /app
 COPY . /app
 RUN rm -rf /app/dist-prod # remove potentially old folder
 RUN yarn
 RUN yarn build
+RUN strip-nondeterminism /app/dist-prod/joule-*.zip
+RUN sha256sum -b /app/dist-prod/joule-*.zip
 #COPY /app/dist-prod/joule-v0.5.2.zip /out
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# This Dockerfile can be used to build a production release of joule:
+#
+# Usage:
+# 1. Build the docker image
+# 2. Get the production distribution .zip file from the image
+
+# $ docker build -t joule .
+# $ docker run --rm -v "$(pwd):/out" joule sh -c "cp /app/dist-prod/joule*.zip /out"
+# ls ./out
+#
+FROM node:lts-alpine
+WORKDIR /app
+COPY . /app
+RUN rm -rf /app/dist-prod # remove potentially old folder
+RUN yarn
+RUN yarn build
+#COPY /app/dist-prod/joule-v0.5.2.zip /out
+


### PR DESCRIPTION
Started a Dockerfile that can be used to create production builds of joule. 
This should make it easier for people to create and verify production builds.

I am not sure what the best approach for this is using docker. 
Currently the docker image needs to be created: 

    $ docker build -t joule .

And then the production .zip can be copied to the host machine:

    $ docker run --rm -v "$(pwd):/out" joule sh -c "cp /app/dist-prod/joule*.zip /out"


joule-vx.x.x.zip will then be in the project root folder.

Alternatively run the production build from the current working directory:

    $ docker run --rm -v "$(pwd):/build" joule sh -c "cd /build && yarn && yarn build"

All build dependencies run in Docker but will create the build `dist-prod` on the host.