### PR TITLE
Create deterministic and verifiable zip package

### DIFF
--- a/create-package.sh
+++ b/create-package.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Extract version from package.json
+VERSION=$(cat package.json | grep -oP '"version": "\K(\d+\.\d+.\d+)(?=")')
+
+echo "Creating zip package for v$VERSION"
+cd dist-prod
+
+# Normalize timestamp to get reproducible zip file
+find . -exec touch -t 200810310000 {} +
+
+# Create zip file
+zip -r ../joule-v$VERSION.zip *
+cd ..
+
+SHA=$(sha512sum -b joule-v$VERSION.zip)
+echo "Created joule-v$VERSION.zip (SHA512: $SHA)"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "npm run build:prod",
     "build:dev": "rimraf dist-dev && cross-env NODE_ENV=development webpack",
     "build:prod": "rimraf dist-prod && cross-env NODE_ENV=production webpack",
+    "package:prod": "./create-package.sh",
     "clean": "rimraf ./dist-dev && rimraf ./dist-prod",
     "lint": "tslint -p tsconfig.json",
     "tsc": "tsc --noEmit",
@@ -97,7 +98,6 @@
     "webln": "0.2.2",
     "webpack": "4.44.2",
     "webpack-cli": "^3.3.12",
-    "zip-webpack-plugin": "3.0.0",
     "zxcvbn": "4.4.2"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,6 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const WriteFilePlugin = require('write-file-webpack-plugin');
-const ZipPlugin = require('zip-webpack-plugin');
 
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -210,9 +209,5 @@ module.exports = {
         ],
       }),
     isDev && new WriteFilePlugin(),
-    !isDev &&
-      new ZipPlugin({
-        filename: `joule-v${packageJson.version}.zip`,
-      }),
   ].filter(p => !!p),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,11 +2288,6 @@ browserslist@^4.12.0, browserslist@^4.8.5:
     node-releases "^1.1.53"
     pkg-up "^2.0.0"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -9321,25 +9316,10 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yazl@^2.4.3:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
-  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
-  dependencies:
-    buffer-crc32 "~0.2.3"
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-
-zip-webpack-plugin@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/zip-webpack-plugin/-/zip-webpack-plugin-3.0.0.tgz#63b3c173f1a87a006915cd7328a3c40b44dc8e32"
-  integrity sha512-5kNvPv+TUP3JqKWQUXj0vTgXHIRQpYw5YyBUVXQ0pumTAK+a4OZ+eXDHnh44nyr9B1XJQZq9WtSSm5j6NQhjWQ==
-  dependencies:
-    webpack-sources "^1.1.0"
-    yazl "^2.4.3"
 
 zxcvbn@4.4.2:
   version "4.4.2"


### PR DESCRIPTION
This is another option to create reproducible zip packages that can be verified. 
To do this we no longer create the zip in the webpack build process but using a small bash script.

The script sets a fixed file timestamp to the `dist-prod` files and creates the zip file. 


related: #260  #268 